### PR TITLE
Fix some OpenSMILE setup issues

### DIFF
--- a/config.py
+++ b/config.py
@@ -9,11 +9,12 @@ DEFAULT_NOT_SET = "dasklhglaskjdlkasj"
 
 if os.path.isfile(CONFIG_FILE):
     cfg = configparser.ConfigParser()
+    # Prevent configparser from converting keys to lowercase
+    cfg.optionxform = str
     cfg.read(CONFIG_FILE)
     _from_cfg_file = cfg._sections["deps"]
 
 def _get_var(key, default=DEFAULT_NOT_SET):
-
     try:
         if key in os.environ:
             return os.environ[key]

--- a/nodes/audio.py
+++ b/nodes/audio.py
@@ -98,7 +98,12 @@ class OpenSmileRunner(FileOutputNode):
         self.out_flag = out_flag
         self.out_ext = out_ext
 
-        self.opensmile_exec = file_utils.locate_file("SMILExtract", [OPENSMILE_HOME, os.path.join(OPENSMILE_HOME, "bin")], use_path=True)
+        opensmile_locations = [
+            OPENSMILE_HOME,
+            os.path.join(OPENSMILE_HOME, "bin"),
+            os.path.join(OPENSMILE_HOME, "bin/linux_x64_standalone_static"),
+        ]
+        self.opensmile_exec = file_utils.locate_file("SMILExtract", opensmile_locations, use_path=True)
 
 
     def run(self, in_file):


### PR DESCRIPTION
This fixes two issues that I ran into while setting this up for OpenSMILE:

1. It looks for `SMILExtract` in `$OPENSMILE_HOME/bin` but couldn't find it because it was actually in `$OPENSMILE_HOME/bin/linux_x64_standalone_static` in my installation.
2. It couldn't parse the `OPENSMILE_HOME` variable from the config because configparser automatically converted it to lowercase. I added a line to prevent this.

The pipeline opensmile_is10 works for me after these changes.