### PR TITLE
Fix bug that causes lex default.conf to throw an error

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -1,7 +1,7 @@
-pos_tokens, pos_ratios # Lexical features go on the first line. Everything after the '#' is ignored.
-rst # Pragmatic features go on the second line
+all # Lexical features go on the first line. Everything after the '#' is ignored.
+all # Pragmatic features go on the second line
 all # Semantic features on the third line. If you write 'all', then all semantic features will be extracted.
-# Syntactic features on the fourth line. If you write nothing, then no syntactic features will be extracted.
+all # Syntactic features on the fourth line. If you write nothing, then no syntactic features will be extracted.
 
 # Extra lines are ignored.
 # Possible values:

--- a/nodes/lexicosyntactic.py
+++ b/nodes/lexicosyntactic.py
@@ -117,7 +117,7 @@ def load_conf(config_file):
         with open(config_file) as f:
             lines = f.readlines()
 
-        if not len(lines) == 4:
+        if len(lines) < 4:
             print('Error with config file. Using default features.')
 
         else:


### PR DESCRIPTION
The `default.conf` file has more than 4 lines, so this line causes it to error.